### PR TITLE
Tasks to set response body content where not being awaited. Sometimes…

### DIFF
--- a/src/GlobalExceptionHandler/WebApi/ExceptionHandlerConfiguration.cs
+++ b/src/GlobalExceptionHandler/WebApi/ExceptionHandlerConfiguration.cs
@@ -6,14 +6,14 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 
 namespace GlobalExceptionHandler.WebApi
-{	
+{
 	public class ExceptionHandlerConfiguration : IUnhandledFormatters
-	{		
+	{
 		private readonly IDictionary<Type, ExceptionConfig> _exceptionConfiguration = new Dictionary<Type, ExceptionConfig>();
-		private Type[] _exceptionConfigurationTypesSortedByDepthDescending;		
+		private Type[] _exceptionConfigurationTypesSortedByDepthDescending;
 		private Func<Exception, HttpContext, Task> _logger;
 
-		internal Func<Exception, HttpContext, HandlerContext, Task> CustomFormatter { get; private set; } 
+		internal Func<Exception, HttpContext, HandlerContext, Task> CustomFormatter { get; private set; }
 		internal Func<Exception, HttpContext, HandlerContext, Task> DefaultFormatter { get; }
 		internal IDictionary<Type, ExceptionConfig> ExceptionConfiguration => _exceptionConfiguration;
 
@@ -47,16 +47,15 @@ namespace GlobalExceptionHandler.WebApi
 		[Obsolete("MessageFormatter(..) is obsolete and will be removed soon, use ResponseBody(..) instead", false)]
 		public void MessageFormatter(Func<Exception, HttpContext, HandlerContext, Task> formatter)
 			=> ResponseBody(formatter);
-		
+
 		public void ResponseBody(Func<Exception, string> formatter)
 		{
 			Task Formatter(Exception x, HttpContext y, HandlerContext b)
 			{
 				var s = formatter.Invoke(x);
-				y.Response.WriteAsync(s);
-				return Task.CompletedTask;
+				return y.Response.WriteAsync(s);
 			}
-			
+
 			ResponseBody(Formatter);
 		}
 
@@ -64,22 +63,20 @@ namespace GlobalExceptionHandler.WebApi
 		{
 			Task Formatter(Exception x, HttpContext y, HandlerContext b)
 			{
-				formatter.Invoke(x, y);
-				return Task.CompletedTask;
+				return formatter.Invoke(x, y);
 			}
-			
+
 			ResponseBody(Formatter);
 		}
-		
+
 		public void ResponseBody(Func<Exception, HttpContext, string> formatter)
 		{
 			Task Formatter(Exception x, HttpContext y, HandlerContext b)
 			{
 				var s = formatter.Invoke(x, y);
-				y.Response.WriteAsync(s);
-				return Task.CompletedTask;
+				return y.Response.WriteAsync(s);
 			}
-			
+
 			ResponseBody(Formatter);
 		}
 
@@ -87,19 +84,19 @@ namespace GlobalExceptionHandler.WebApi
 		{
 			CustomFormatter = formatter;
 		}
-		
+
 		public void OnError(Func<Exception, HttpContext, Task> log)
 		{
 			_logger = log;
 		}
-		
+
 		internal RequestDelegate BuildHandler()
 		{
 			var handlerContext = new HandlerContext
 			{
 				ContentType = ContentType
 			};
-			
+
 			_exceptionConfigurationTypesSortedByDepthDescending = _exceptionConfiguration.Keys
 				.OrderByDescending(x => x, new ExceptionTypePolymorphicComparer())
 				.ToArray();
@@ -107,10 +104,10 @@ namespace GlobalExceptionHandler.WebApi
 			return async context =>
 			{
 				var exception = context.Features.Get<IExceptionHandlerFeature>().Error;
-				
+
 				if (ContentType != null)
 					context.Response.ContentType = ContentType;
-				
+
 				// If any custom exceptions are set
 				foreach (Type type in _exceptionConfigurationTypesSortedByDepthDescending)
 				{
@@ -141,6 +138,6 @@ namespace GlobalExceptionHandler.WebApi
 				if (DebugMode)
 					await DefaultFormatter(exception, context, handlerContext);
 			};
-		}		
+		}
 	}
 }

--- a/src/GlobalExceptionHandler/WebApi/ExceptionRuleCreator.cs
+++ b/src/GlobalExceptionHandler/WebApi/ExceptionRuleCreator.cs
@@ -52,7 +52,7 @@ namespace GlobalExceptionHandler.WebApi
         public void UsingMessageFormatter(Func<Exception, HttpContext, string> formatter)
             => WithBody(formatter);
 
-        public void UsingMessageFormatter(Func<Exception, HttpContext, Task> formatter) 
+        public void UsingMessageFormatter(Func<Exception, HttpContext, Task> formatter)
             => WithBody(formatter);
 
         public void UsingMessageFormatter(Func<Exception, HttpContext, HandlerContext, Task> formatter)
@@ -63,8 +63,7 @@ namespace GlobalExceptionHandler.WebApi
             Task Formatter(Exception x, HttpContext y, HandlerContext b)
             {
                 var s = formatter.Invoke(x, y);
-                y.Response.WriteAsync(s);
-                return Task.CompletedTask;
+                return y.Response.WriteAsync(s);
             }
 
             UsingMessageFormatter(Formatter);
@@ -77,13 +76,12 @@ namespace GlobalExceptionHandler.WebApi
 
             Task Formatter(Exception x, HttpContext y, HandlerContext b)
             {
-                formatter.Invoke(x, y);
-                return Task.CompletedTask;
+                return formatter.Invoke(x, y);
             }
 
             UsingMessageFormatter(Formatter);
         }
-        
+
         private void WithBody(Func<Exception, HttpContext, HandlerContext, Task> formatter)
             => SetMessageFormatter(formatter);
 
@@ -100,7 +98,7 @@ namespace GlobalExceptionHandler.WebApi
     internal class ExceptionRuleCreator<TException> : IHasStatusCode<TException>, IHandledFormatters<TException> where TException: Exception
     {
         private readonly IDictionary<Type, ExceptionConfig> _configurations;
-        
+
         public ExceptionRuleCreator(IDictionary<Type, ExceptionConfig> configurations)
         {
             _configurations = configurations;
@@ -111,10 +109,10 @@ namespace GlobalExceptionHandler.WebApi
 
         public IHandledFormatters<TException> ToStatusCode(HttpStatusCode statusCode)
             => ToStatusCodeImpl(ex => (int)statusCode);
-        
+
         public IHandledFormatters<TException> ToStatusCode(Func<TException, int> statusCodeResolver)
             => ToStatusCodeImpl(statusCodeResolver);
-        
+
         public IHandledFormatters<TException> ToStatusCode(Func<TException, HttpStatusCode> statusCodeResolver)
             => ToStatusCodeImpl(x => (int)statusCodeResolver(x));
 
@@ -136,8 +134,7 @@ namespace GlobalExceptionHandler.WebApi
             Task Formatter(TException x, HttpContext y, HandlerContext b)
             {
                 var s = formatter.Invoke(x, y);
-                y.Response.WriteAsync(s);
-                return Task.CompletedTask;
+                return y.Response.WriteAsync(s);
             }
 
             UsingMessageFormatter(Formatter);
@@ -150,8 +147,7 @@ namespace GlobalExceptionHandler.WebApi
 
             Task Formatter(TException x, HttpContext y, HandlerContext b)
             {
-                formatter.Invoke(x, y);
-                return Task.CompletedTask;
+                return formatter.Invoke(x, y);
             }
 
             UsingMessageFormatter(Formatter);
@@ -160,7 +156,7 @@ namespace GlobalExceptionHandler.WebApi
         public void UsingMessageFormatter(Func<TException, HttpContext, HandlerContext, Task> formatter)
             => WithBody(formatter);
 
-        
+
         public void WithBody(Func<TException, HttpContext, HandlerContext, Task> formatter)
             => SetMessageFormatter(formatter);
 


### PR DESCRIPTION
… the response was being returned before task finishes which resulted in the responses having no content